### PR TITLE
句読点などが真ん中に表示されてしまうことの修正

### DIFF
--- a/homepage/public/css/style.css
+++ b/homepage/public/css/style.css
@@ -1,5 +1,5 @@
 * {
-  font-family: 'Josefin Sans', 'Noto Sans TC', sans-serif;
+  font-family: 'Josefin Sans', 'Noto Sans JP', 'Noto Sans TC', sans-serif;
 }
 html {
   scroll-behavior: smooth;


### PR DESCRIPTION
# 概要

## 修正前
<img width="1728" height="826" alt="修正前" src="https://github.com/user-attachments/assets/07f0c156-b391-46bd-83de-f9c9b829a8d7" />

## 修正後
<img width="839" height="801" alt="修正後" src="https://github.com/user-attachments/assets/333dac7f-38d6-45b0-a67e-7f7460f86c17" />

## 概要
フォントにNoto Sans TCを使っていることが原因。
Noto Sans JPをCSSのfont-familyに追加することで解決した。
