### PR TITLE
fix: unify defaultLocale to 'ja' across all files #9

### DIFF
--- a/homepage/src/pages/404.jsx
+++ b/homepage/src/pages/404.jsx
@@ -27,7 +27,7 @@ export const getStaticProps = async ({ locale }) => {
 
   const layout = await getLayout(locale);
 
-  const defaultLocale = 'zh-Hant';
+  const defaultLocale = 'ja';
   return {
     props: {
       headInfo: {

--- a/homepage/src/pages/_app.jsx
+++ b/homepage/src/pages/_app.jsx
@@ -42,7 +42,7 @@ const getDefaultLayout = (page, pageProps, siteData) => {
   );
 };
 
-const defaultLocale = 'zh-Hant';
+const defaultLocale = 'ja';
 
 export default function App({ Component, pageProps, router }) {
   const siteData = siteDataDictionary[router.locale] ?? siteDataDictionary[defaultLocale];

--- a/homepage/src/pages/cards.jsx
+++ b/homepage/src/pages/cards.jsx
@@ -20,7 +20,7 @@ export const getStaticProps = async ({ locale }) => {
 
   const layout = await getLayout(locale);
 
-  const defaultLocale = 'zh-Hant';
+  const defaultLocale = 'ja';
   return {
     props: {
       headInfo: {

--- a/homepage/src/pages/index.jsx
+++ b/homepage/src/pages/index.jsx
@@ -25,7 +25,7 @@ export const getStaticProps = async ({ locale }) => {
 
   const layout = await getLayout(locale);
 
-  const defaultLocale = 'zh-Hant';
+  const defaultLocale = 'ja';
   return {
     props: {
       headInfo: {

--- a/homepage/src/pages/resource.jsx
+++ b/homepage/src/pages/resource.jsx
@@ -20,7 +20,7 @@ export const getStaticProps = async ({ locale }) => {
 
   const layout = await getLayout(locale);
 
-  const defaultLocale = 'zh-Hant';
+  const defaultLocale = 'ja';
   return {
     props: {
       headInfo: {


### PR DESCRIPTION
# Description
`next.config.js` の `defaultLocale: 'ja'` と各ページファイル内のフォールバック用 `defaultLocale` 変数が `'zh-Hant'` になっていた不整合を修正しました。

Closes #9

## minor
- `src/pages/_app.jsx` の `defaultLocale` を `'zh-Hant'` → `'ja'` に変更
- `src/pages/404.jsx` の `defaultLocale` を `'zh-Hant'` → `'ja'` に変更