### PR TITLE
[ja] 日本語フォント（Noto Sans JP）が読み込まれていない #8

### DIFF
--- a/homepage/src/pages/_document.jsx
+++ b/homepage/src/pages/_document.jsx
@@ -20,6 +20,11 @@ export default function Document({ locale }) {
           type="text/css"
         />
         <link
+          href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@300;400;600;700&display=swap"
+          rel="stylesheet"
+          type="text/css"
+        />
+        <link
           href="https://fonts.googleapis.com/css?family=Noto+Sans+TC:300,400,400i,600,700,700i&display=swap"
           rel="stylesheet"
           type="text/css"


### PR DESCRIPTION
## Summary
- `_document.jsx` に Google Fonts から Noto Sans JP を読み込む `<link>` タグを追加
- `style.css` の `font-family` には既に `Noto Sans JP` が含まれていたため変更なし