### PR TITLE
[a11y][SEO] <Html> タグに lang 属性が設定されていない #7

### DIFF
--- a/homepage/src/pages/_document.jsx
+++ b/homepage/src/pages/_document.jsx
@@ -1,7 +1,8 @@
 import { Html, Head, Main, NextScript } from 'next/document';
 import { GTM_ID } from '../lib/service/gtm';
 
-export default function Document({ locale }) {
+export default function Document(props) {
+  const locale = props.locale || props.defaultLocale || 'ja';
   return (
     <Html lang={locale}>
       <Head>


### PR DESCRIPTION
## Summary
`_document.jsx` の `<Html>` タグに `lang` 属性を追加しました。

## Changes
| ファイル | 変更内容 |
|---|---|
| `_document.jsx` | `<Html lang={locale}>` を追加、`props.locale \|\| props.defaultLocale \|\| 'ja'` でロケール取得 |

## Notes
- AIレビュー（CodeRabbit）の指摘に対応済み
- `props.locale` が未定義の場合は `defaultLocale`、それも未定義なら `'ja'` にフォールバック