### PR TITLE
[ja] 404ページの <h1> が全言語で "NOT FOUND" の英語ハードコード #6

### DIFF
--- a/homepage/src/pages/404.jsx
+++ b/homepage/src/pages/404.jsx
@@ -10,8 +10,14 @@ export const getStaticProps = async ({ locale }) => {
     title: {
       en: `OpenStarTerVillage - Page Not Found`,
       'zh-Hant': `開源星手村 - 找不到網頁`,
-      ja: `オープンスターターヴィレッジ - ページが見つかりません`,
+      ja: `オープンソースクエスト - ページが見つかりません`,
     },
+  };
+
+  const heading = {
+    en: `Page Not Found`,
+    'zh-Hant': `找不到網頁`,
+    ja: `ページが見つかりません`,
   };
 
   const desc = {
@@ -35,13 +41,14 @@ export const getStaticProps = async ({ locale }) => {
         title: headInfo.title[locale] ?? headInfo.title[defaultLocale],
         description: '',
       },
+      heading: heading[locale] ?? heading[defaultLocale],
       desc: desc[locale] ?? desc[defaultLocale],
       layout,
     },
   };
 };
 
-const NotFoundPage = ({ headInfo, desc }) => (
+const NotFoundPage = ({ headInfo, heading, desc }) => (
   <>
     <Head>
       <title>{headInfo.title}</title>
@@ -49,7 +56,7 @@ const NotFoundPage = ({ headInfo, desc }) => (
     </Head>
     <div className="site-container not-found-page">
       <div className="container text-center">
-        <h1>NOT FOUND</h1>
+        <h1>{heading}</h1>
         <p
           dangerouslySetInnerHTML={{
             __html: desc,


### PR DESCRIPTION
## Summary
404 페이지의 `<h1>`을 로케일에 맞는 문구로 대응하고, 일본어 제목명을 수정했습니다.

## Changes
| 파일 | 변경 내용 |
|---|---|
| `src/pages/404.jsx` | `<h1>NOT FOUND</h1>` 을 로케일별로 대응하고, `heading` 오브젝트 추가 |
| `src/pages/404.jsx` | `ja` 제목을 `오픈소스퀘스트` 로 수정 |

## Locale
| 로케일 | 표시 텍스트 |
|---|---|
| ja | 페이지를 찾을 수 없습니다 |
| en | Page Not Found |
| zh-Hant | 접속할 수 없는 웹 페이지 |